### PR TITLE
Update Teltek get video id method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metagroup-schema-tools",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Metagroup (like vigotech.org) schema tools",
   "main": "src/index.js",
   "repository": "git@github.com:VigoTech/metagroup-schema-tools.git",

--- a/src/videos/teltek.js
+++ b/src/videos/teltek.js
@@ -7,14 +7,18 @@ module.exports = {
     let feed = await parser.parseURL(source.source);
 
     feed.items.forEach(item => {
-      results.push({
-        player: 'native', //'teltek',
-        id: item.link.match(/pumukit\/(.*)\/(.*)\.mp4/)[2],
-        src: item.link,
-        title: item.title,
-        pubDate: new Date(item.pubDate).getTime(),
-        thumbnail: item.itunes.image
-      })
+      try {
+        results.push({
+          player: 'native',
+          id: item.guid.match(/pumukit\/(.*)\/(.*)\.mp4/)[2],
+          src: item.link,
+          title: item.title,
+          pubDate: new Date(item.pubDate).getTime(),
+          thumbnail: item.itunes.image
+        })
+      } catch (e) {
+        console.log('Error getting Teltek videos')
+      }
     });
     return results
   }


### PR DESCRIPTION
Debido a un campo na resposta de Telket en lugar de empregar o link para obter o id empregamos o guid
Ademáis engadimos captura de erros para evitar futuros problemas