### PR TITLE
Capture video fetch exceptions to avoid exit process on error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metagroup-schema-tools",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Metagroup (like vigotech.org) schema tools",
   "main": "src/index.js",
   "repository": "git@github.com:VigoTech/metagroup-schema-tools.git",

--- a/src/videos.js
+++ b/src/videos.js
@@ -34,13 +34,17 @@ const Videos = {
     const eventEmitter = Videos.getEventsEmitter()
     eventEmitter.emit('getVideosFromSourceInit', source, options)
 
-    switch (source.type) {
-      case 'youtube':
-        videos = await YoutubeVideos.getChannelVideos(source, limit, options)
-        break;
-      case 'teltek':
-        videos = await TeltekVideos.getVideos(source, limit, options);
-        break;
+    try {
+      switch (source.type) {
+        case 'youtube':
+          videos = await YoutubeVideos.getChannelVideos(source, limit, options)
+          break;
+        case 'teltek':
+          videos = await TeltekVideos.getVideos(source, limit, options);
+          break;
+      }
+    } catch (e) {
+      console.error(source, e)
     }
 
     eventEmitter.emit('getVideosFromSourceCompleted', videos, options)


### PR DESCRIPTION
Teltek URLs are responding 500: https://replay.teltek.es/podcast/series/58af67c7a7bc283f008b456c/collection.xml and that cause an exception fetching videos on website exiting the import process.
Added a try-catch block to capture the exception allowing the process continues