### PR TITLE
Fix Meetup RSS parsing and add opt-in live E2E test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-test
 .env
 .idea
 
@@ -77,4 +76,3 @@ typings/
 
 # Serverless directories
 .serverless
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+test/*
+!test/meetup.test.js
 .env
 .idea
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,14 @@ Básicamente esta estructura permite definir o Metagrupo (co seu logo, links a r
 A chave `events` poder ser un obxecto único ou un array de obxectos, que define as fontes de eventos de dito grupo
 
 As fontes posibles actuais son:
-* Meetup: 
+* Meetup (via RSS feed): 
   `
   {
     "type": "meetup",
     "meetupid": "AIndustriosa"
   }
   `
+  Obtén os eventos desde `https://www.meetup.com/[GROUP ID]/events/rss/`. Debido ás limitacións actuais de Meetup, os eventos pasados non están dispoñibles nesta fonte e `getPrevFromSource(source, options)` devolverá un array baleiro para fontes Meetup.
 * Eventbrite: 
   `
   {

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Provee métodos para importar e normalizar os próximos das distintas fontes
   * `getVideosFromSource(source, limit, options)` obten os videos dunha fonte. *Método asíncrono*
         
       
-  En todos os casos _options_ é un obxecto no que se pasan elementos que poden precisar cada un dos importadores, por exemplo, o importador de *youtube* precisa o _youtubeApiKey_ para poder funcionar.
+  En todos os casos _options_ é un obxecto no que se pasan elementos que poden precisar cada un dos importadores. O importador de *youtube* emprega a fonte RSS pública da canle, polo que non precisa chave de API.
   
   
 ## Exemplo de importador

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,371 @@
+{
+  "name": "metagroup-schema-tools",
+  "version": "1.0.9",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "metagroup-schema-tools",
+      "version": "1.0.9",
+      "license": "MIT",
+      "dependencies": {
+        "jsonschema": "^1.4.0",
+        "moment": "^2.29.1",
+        "rss-parser": "^3.12.0",
+        "sync-request": "^6.1.0"
+      },
+      "devDependencies": {
+        "colors": "^1.3.3"
+      }
+    },
+    "node_modules/@types/concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/form-data": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "13.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.3.tgz",
+      "license": "MIT"
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "license": "MIT"
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "license": "MIT"
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "license": "Apache-2.0"
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/get-port": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/http-basic": {
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^1.6.2",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "license": "MIT"
+    },
+    "node_modules/jsonschema": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.43.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "license": "MIT"
+    },
+    "node_modules/promise": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "asap": "~2.0.6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.2.tgz",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "license": "MIT"
+    },
+    "node_modules/rss-parser": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.12.0.tgz",
+      "integrity": "sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.4.19"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "license": "ISC"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "license": "MIT"
+    },
+    "node_modules/sync-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "http-response-object": "^3.0.1",
+        "sync-rpc": "^1.2.1",
+        "then-request": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/sync-rpc": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "get-port": "^3.1.0"
+      }
+    },
+    "node_modules/then-request": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@types/concat-stream": "^1.6.0",
+        "@types/form-data": "0.0.33",
+        "@types/node": "^8.0.0",
+        "@types/qs": "^6.2.31",
+        "caseless": "~0.12.0",
+        "concat-stream": "^1.6.0",
+        "form-data": "^2.2.0",
+        "http-basic": "^8.1.1",
+        "http-response-object": "^3.0.1",
+        "promise": "^8.0.0",
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/then-request/node_modules/@types/node": {
+      "version": "8.10.59",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz",
+      "license": "MIT"
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "license": "MIT"
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metagroup-schema-tools",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Metagroup (like vigotech.org) schema tools",
   "main": "src/index.js",
   "scripts": {
@@ -18,7 +18,6 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "googleapis": "^74.2.0",
     "jsonschema": "^1.4.0",
     "moment": "^2.29.1",
     "rss-parser": "^3.12.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "metagroup-schema-tools",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Metagroup (like vigotech.org) schema tools",
   "main": "src/index.js",
+  "scripts": {
+    "test": "node --test test/meetup.test.js"
+  },
   "repository": "git@github.com:VigoTech/metagroup-schema-tools.git",
   "author": "VigoTech Alliance <vigotechalliance@gmail.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metagroup-schema-tools",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Metagroup (like vigotech.org) schema tools",
   "main": "src/index.js",
   "scripts": {

--- a/src/events/meetup.js
+++ b/src/events/meetup.js
@@ -1,20 +1,173 @@
-const request = require("sync-request")
+const moment = require('moment')
+const request = require('sync-request')
+
+function decodeHtml(value) {
+  return (value || '')
+    .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
+    .replace(/\\,/g, ',')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .trim()
+}
+
+function getTagValue(block, tag) {
+  const regex = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`, 'i')
+  const match = block.match(regex)
+  return match ? decodeHtml(match[1]) : ''
+}
+
+function getJsonLdEvent(html) {
+  const matches = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/gi) || []
+
+  for (let index = 0; index < matches.length; index++) {
+    const match = matches[index].match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/i)
+
+    if (!match) {
+      continue
+    }
+
+    try {
+      const data = JSON.parse(match[1])
+      if (data['@type'] === 'Event') {
+        return data
+      }
+    } catch (e) {
+      continue
+    }
+  }
+
+  return null
+}
+
+function getLocationFromEventData(eventData) {
+  if (!eventData || !eventData.location) {
+    return ''
+  }
+
+  if (eventData.eventAttendanceMode === 'https://schema.org/OnlineEventAttendanceMode') {
+    return 'Online event'
+  }
+
+  if (eventData.location['@type'] === 'VirtualLocation') {
+    return 'Online event'
+  }
+
+  const location = eventData.location
+  const address = location.address || {}
+  return [
+    location.name,
+    address.streetAddress,
+    address.addressLocality,
+    address.addressRegion,
+    address.postalCode,
+    address.addressCountry
+  ].filter(Boolean).join(' - ')
+}
+
+function getDateFromDescription(description) {
+  const normalized = description
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\r/g, '')
+
+  const lines = normalized
+    .split('\n')
+    .map(line => decodeHtml(line).replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+
+  const dateLine = lines.find(line => /(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|June|July|August|September|October|November|December)\s+\d{1,2},\s+\d{4}/i.test(line))
+
+  if (!dateLine) {
+    return null
+  }
+
+  const cleaned = dateLine.replace(/^[^A-Za-z0-9]+/, '').split(' - ')[0].trim()
+  const formats = [
+    'MMMM D, YYYY | HH:mm',
+    'MMMM D, YYYY | H:mm',
+    'MMM D, YYYY | HH:mm',
+    'MMM D, YYYY | H:mm'
+  ]
+
+  const parsed = moment(cleaned, formats, true)
+  return parsed.isValid() ? parsed.valueOf() : null
+}
+
+function getLocationFromDescription(description) {
+  const normalized = description
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\r/g, '')
+
+  const lines = normalized
+    .split('\n')
+    .map(line => decodeHtml(line).replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+
+  const locationLine = lines.find(line => /^(📍|location[: ]|online\b)/i.test(line))
+
+  if (!locationLine) {
+    return ''
+  }
+
+  return locationLine.replace(/^📍\s*/i, '').trim()
+}
+
+function getEventDetails(url, description) {
+  try {
+    const pageRaw = request('GET', url)
+    const page = pageRaw.getBody('utf8')
+    const eventData = getJsonLdEvent(page)
+
+    if (eventData) {
+      return {
+        date: eventData.startDate ? new Date(eventData.startDate).getTime() : getDateFromDescription(description),
+        location: getLocationFromEventData(eventData) || getLocationFromDescription(description)
+      }
+    }
+  } catch (e) {
+    console.log(e)
+  }
+
+  return {
+    date: getDateFromDescription(description),
+    location: getLocationFromDescription(description)
+  }
+}
+
+function getFeedItems(source) {
+  const feedUrl = `https://www.meetup.com/${source.meetupid}/events/rss/`
+  const dataRaw = request('GET', feedUrl)
+  const xml = dataRaw.getBody('utf8')
+  const items = xml.match(/<item>([\s\S]*?)<\/item>/gi) || []
+
+  return items.map(itemBlock => ({
+    title: getTagValue(itemBlock, 'title'),
+    url: getTagValue(itemBlock, 'link'),
+    description: getTagValue(itemBlock, 'description')
+  }))
+}
 
 module.exports = {
-  getNext (source, options) {
+  getNext(source, options) {
     const nextEvents = []
-    try {
-      const dataRaw = request('GET', `http://api.meetup.com/${source.meetupid}/events`)
-      const data = JSON.parse(dataRaw.getBody('utf8'))
 
-      Object.keys(data).forEach(key => {
-        let item = data[key]
-        nextEvents.push({
-          title: item.name,
-          date: item.time,
-          url: item.link,
-          location: item.how_to_find_us || ''
-        })
+    try {
+      getFeedItems(source).forEach(item => {
+        const eventDetails = getEventDetails(item.url, item.description)
+
+        if (eventDetails.date !== null && eventDetails.date >= new Date().getTime()) {
+          nextEvents.push({
+            title: item.title,
+            date: eventDetails.date,
+            url: item.url,
+            location: eventDetails.location || ''
+          })
+        }
       })
     } catch (e) {
       console.log(e)
@@ -23,30 +176,7 @@ module.exports = {
     return nextEvents
   },
 
-  getPrev (source, options) {
-    const prevEvents = []
-    try {
-      const dataRaw = request('GET', `http://api.meetup.com/${source.meetupid}/events`, {
-        qs: {
-          status: 'past'
-        }
-      })
-      console.log(`http://api.meetup.com/${source.meetupid}/events`)
-      const data = JSON.parse(dataRaw.getBody('utf8'))
-
-      Object.keys(data).forEach(key => {
-        let item = data[key]
-        prevEvents.push({
-          title: item.name,
-          date: item.time,
-          url: item.link,
-          location: item.how_to_find_us || ''
-        })
-      })
-    } catch (e) {
-      console.log(e)
-    }
-
-    return prevEvents
+  getPrev(source, options) {
+    return []
   }
 }

--- a/src/events/meetup.js
+++ b/src/events/meetup.js
@@ -1,6 +1,32 @@
 const moment = require('moment')
 const request = require('sync-request')
 
+function slugify(value) {
+  return String(value || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
+function getSourceId(source, item, date) {
+  const itemUrl = item.url || ''
+  const idFromUrlMatch = itemUrl.match(/\/events\/(\d+)\/?$/)
+  const idFromUrl = idFromUrlMatch ? idFromUrlMatch[1] : null
+  const groupId = source && source.meetupid ? source.meetupid : 'meetup'
+
+  if (idFromUrl) {
+    return `${groupId}-${idFromUrl}`
+  }
+
+  if (date) {
+    return `${groupId}-${date}-${slugify(item.title || 'event')}`
+  }
+
+  return `${groupId}-${slugify(item.title || 'event')}`
+}
+
 function decodeHtml(value) {
   return (value || '')
     .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1')
@@ -162,6 +188,7 @@ module.exports = {
 
         if (eventDetails.date !== null && eventDetails.date >= new Date().getTime()) {
           nextEvents.push({
+            sourceId: getSourceId(source, item, eventDetails.date),
             title: item.title,
             date: eventDetails.date,
             url: item.url,

--- a/src/events/meetup.js
+++ b/src/events/meetup.js
@@ -47,19 +47,33 @@ function getTagValue(block, tag) {
 }
 
 function getJsonLdEvent(html) {
-  const matches = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/gi) || []
+  const matches =
+    html.matchAll(
+      /<script[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi,
+    ) || []
 
-  for (let index = 0; index < matches.length; index++) {
-    const match = matches[index].match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/i)
-
-    if (!match) {
-      continue
-    }
-
+  for (const match of matches) {
     try {
       const data = JSON.parse(match[1])
-      if (data['@type'] === 'Event') {
+
+      if (data && data['@type'] === 'Event') {
         return data
+      }
+
+      if (Array.isArray(data)) {
+        const event = data.find((item) => item && item['@type'] === 'Event')
+        if (event) {
+          return event
+        }
+      }
+
+      if (data && Array.isArray(data['@graph'])) {
+        const event = data['@graph'].find(
+          (item) => item && item['@type'] === 'Event',
+        )
+        if (event) {
+          return event
+        }
       }
     } catch (e) {
       continue
@@ -74,7 +88,10 @@ function getLocationFromEventData(eventData) {
     return ''
   }
 
-  if (eventData.eventAttendanceMode === 'https://schema.org/OnlineEventAttendanceMode') {
+  if (
+    eventData.eventAttendanceMode ===
+    'https://schema.org/OnlineEventAttendanceMode'
+  ) {
     return 'Online event'
   }
 
@@ -90,8 +107,10 @@ function getLocationFromEventData(eventData) {
     address.addressLocality,
     address.addressRegion,
     address.postalCode,
-    address.addressCountry
-  ].filter(Boolean).join(' - ')
+    address.addressCountry,
+  ]
+    .filter(Boolean)
+    .join(' - ')
 }
 
 function getDateFromDescription(description) {
@@ -102,21 +121,28 @@ function getDateFromDescription(description) {
 
   const lines = normalized
     .split('\n')
-    .map(line => decodeHtml(line).replace(/\s+/g, ' ').trim())
+    .map((line) => decodeHtml(line).replace(/\s+/g, ' ').trim())
     .filter(Boolean)
 
-  const dateLine = lines.find(line => /(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|June|July|August|September|October|November|December)\s+\d{1,2},\s+\d{4}/i.test(line))
+  const dateLine = lines.find((line) =>
+    /(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|June|July|August|September|October|November|December)\s+\d{1,2},\s+\d{4}/i.test(
+      line,
+    ),
+  )
 
   if (!dateLine) {
     return null
   }
 
-  const cleaned = dateLine.replace(/^[^A-Za-z0-9]+/, '').split(' - ')[0].trim()
+  const cleaned = dateLine
+    .replace(/^[^A-Za-z0-9]+/, '')
+    .split(' - ')[0]
+    .trim()
   const formats = [
     'MMMM D, YYYY | HH:mm',
     'MMMM D, YYYY | H:mm',
     'MMM D, YYYY | HH:mm',
-    'MMM D, YYYY | H:mm'
+    'MMM D, YYYY | H:mm',
   ]
 
   const parsed = moment(cleaned, formats, true)
@@ -131,10 +157,12 @@ function getLocationFromDescription(description) {
 
   const lines = normalized
     .split('\n')
-    .map(line => decodeHtml(line).replace(/\s+/g, ' ').trim())
+    .map((line) => decodeHtml(line).replace(/\s+/g, ' ').trim())
     .filter(Boolean)
 
-  const locationLine = lines.find(line => /^(📍|location[: ]|online\b)/i.test(line))
+  const locationLine = lines.find((line) =>
+    /^(📍|location[: ]|online\b)/i.test(line),
+  )
 
   if (!locationLine) {
     return ''
@@ -151,8 +179,12 @@ function getEventDetails(url, description) {
 
     if (eventData) {
       return {
-        date: eventData.startDate ? new Date(eventData.startDate).getTime() : getDateFromDescription(description),
-        location: getLocationFromEventData(eventData) || getLocationFromDescription(description)
+        date: eventData.startDate
+          ? new Date(eventData.startDate).getTime()
+          : getDateFromDescription(description),
+        location:
+          getLocationFromEventData(eventData) ||
+          getLocationFromDescription(description),
       }
     }
   } catch (e) {
@@ -161,7 +193,7 @@ function getEventDetails(url, description) {
 
   return {
     date: getDateFromDescription(description),
-    location: getLocationFromDescription(description)
+    location: getLocationFromDescription(description),
   }
 }
 
@@ -171,10 +203,10 @@ function getFeedItems(source) {
   const xml = dataRaw.getBody('utf8')
   const items = xml.match(/<item>([\s\S]*?)<\/item>/gi) || []
 
-  return items.map(itemBlock => ({
+  return items.map((itemBlock) => ({
     title: getTagValue(itemBlock, 'title'),
     url: getTagValue(itemBlock, 'link'),
-    description: getTagValue(itemBlock, 'description')
+    description: getTagValue(itemBlock, 'description'),
   }))
 }
 
@@ -183,16 +215,19 @@ module.exports = {
     const nextEvents = []
 
     try {
-      getFeedItems(source).forEach(item => {
+      getFeedItems(source).forEach((item) => {
         const eventDetails = getEventDetails(item.url, item.description)
 
-        if (eventDetails.date !== null && eventDetails.date >= new Date().getTime()) {
+        if (
+          eventDetails.date !== null &&
+          eventDetails.date >= new Date().getTime()
+        ) {
           nextEvents.push({
             sourceId: getSourceId(source, item, eventDetails.date),
             title: item.title,
             date: eventDetails.date,
             url: item.url,
-            location: eventDetails.location || ''
+            location: eventDetails.location || '',
           })
         }
       })
@@ -205,5 +240,5 @@ module.exports = {
 
   getPrev(source, options) {
     return []
-  }
+  },
 }

--- a/src/events/meetup.js
+++ b/src/events/meetup.js
@@ -137,6 +137,7 @@ function getDateFromDescription(description) {
   const cleaned = dateLine
     .replace(/^[^A-Za-z0-9]+/, '')
     .split(' - ')[0]
+    .replace(/(\|\s*\d{1,2}:\d{2})\s*[-–]\s*\d{1,2}:\d{2}\b/, '$1')
     .trim()
   const formats = [
     'MMMM D, YYYY | HH:mm',

--- a/src/videos/youtube.js
+++ b/src/videos/youtube.js
@@ -1,52 +1,68 @@
-const request = require("sync-request")
-const { google } = require('googleapis');
+const RssParser = require('rss-parser')
+
+const parser = new RssParser()
+
+function getVideoId(item) {
+  if (item.id) {
+    const parts = item.id.split(':')
+    return parts[parts.length - 1]
+  }
+
+  if (item.link) {
+    try {
+      const url = new URL(item.link)
+      return url.searchParams.get('v')
+    } catch (e) {
+      return null
+    }
+  }
+
+  return null
+}
+
+function getThumbnails(videoId) {
+  return {
+    default: {
+      url: `https://i.ytimg.com/vi/${videoId}/default.jpg`,
+      width: 120,
+      height: 90
+    },
+    medium: {
+      url: `https://i.ytimg.com/vi/${videoId}/mqdefault.jpg`,
+      width: 320,
+      height: 180
+    },
+    high: {
+      url: `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`,
+      width: 480,
+      height: 360
+    }
+  }
+}
 
 module.exports = {
   async getChannelVideos(source, limit, options) {
-
-    if (!options.hasOwnProperty('youtubeApiKey')) {
-      throw new Error('Property \'youtubeApiKey\' is required in options object')
-    }
-
-
     if (!source.channel_id) {
       return []
     }
-    const YouTube = google.youtube('v3');
+
+    const feed = await parser.parseURL(`https://www.youtube.com/feeds/videos.xml?channel_id=${source.channel_id}`)
     const videos = []
 
-    const channelResults = await YouTube.channels.list({
-      part: 'contentDetails',
-      id: source.channel_id,
-      limit,
-      auth: options.youtubeApiKey
-    })
+    for (const item of feed.items.slice(0, limit)) {
+      const videoId = getVideoId(item)
 
-    const channelItems = channelResults.data.items;
-    for(let i in channelItems) {
-      const channelItem = channelItems[i]
-      const playlistId = channelItem.contentDetails.relatedPlaylists.uploads
-
-      const playlistResults = await YouTube.playlistItems.list({
-        part: 'snippet',
-        playlistId: playlistId,
-        maxResults: limit,
-        auth: options.youtubeApiKey
-      });
-
-      const playlistItems = playlistResults.data.items;
-      for(let j in playlistItems) {
-        const playlistItem = playlistItems[j]
-
-        videos.push({
-          player: 'youtube',
-          id: playlistItem.snippet.resourceId.videoId,
-          title: playlistItem.snippet.title,
-          pubDate: new Date(playlistItem.snippet.publishedAt).getTime(),
-          thumbnails: playlistItem.snippet.thumbnails
-        })
+      if (!videoId) {
+        continue
       }
 
+      videos.push({
+        player: 'youtube',
+        id: videoId,
+        title: item.title,
+        pubDate: new Date(item.isoDate || item.pubDate).getTime(),
+        thumbnails: getThumbnails(videoId)
+      })
     }
 
     return videos

--- a/test/meetup.test.js
+++ b/test/meetup.test.js
@@ -1,0 +1,108 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const Module = require('module')
+const path = require('path')
+
+const meetupModulePath = path.resolve(__dirname, '../src/events/meetup.js')
+
+function loadMeetupWithMockedRequest(mockRequest) {
+  const originalLoad = Module._load
+
+  delete require.cache[meetupModulePath]
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === 'sync-request') {
+      return mockRequest
+    }
+
+    return originalLoad.apply(this, arguments)
+  }
+
+  try {
+    return require(meetupModulePath)
+  } finally {
+    Module._load = originalLoad
+  }
+}
+
+test('Meetup getNext parses upcoming RSS events from JSON-LD pages', () => {
+  const calls = []
+  const now = Date.now()
+  const futureDate = new Date(now + 7 * 24 * 60 * 60 * 1000).toISOString()
+  const pastDate = new Date(now - 7 * 24 * 60 * 60 * 1000).toISOString()
+  const rssFeed = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title><![CDATA[Future Event]]></title>
+      <link>https://www.meetup.com/test-group/events/1/</link>
+      <description><![CDATA[📍 ONLINE<br />🗓 March 26, 2026 | 18:00-20:30]]></description>
+    </item>
+    <item>
+      <title><![CDATA[Past Event]]></title>
+      <link>https://www.meetup.com/test-group/events/2/</link>
+      <description><![CDATA[📍 Old venue<br />🗓 March 20, 2020 | 18:00-20:30]]></description>
+    </item>
+  </channel>
+</rss>`
+  const eventPages = {
+    'https://www.meetup.com/test-group/events/1/': `<html><head><script type="application/ld+json">${JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'Event',
+      startDate: futureDate,
+      eventAttendanceMode: 'https://schema.org/OnlineEventAttendanceMode',
+      location: {
+        '@type': 'VirtualLocation',
+        url: 'https://www.meetup.com/test-group/events/1/'
+      }
+    })}</script></head></html>`,
+    'https://www.meetup.com/test-group/events/2/': `<html><head><script type="application/ld+json">${JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'Event',
+      startDate: pastDate,
+      location: {
+        '@type': 'Place',
+        name: 'Old venue'
+      }
+    })}</script></head></html>`
+  }
+
+  const meetup = loadMeetupWithMockedRequest((method, url) => {
+    calls.push({ method, url })
+
+    if (url === 'https://www.meetup.com/test-group/events/rss/') {
+      return {
+        getBody() {
+          return rssFeed
+        }
+      }
+    }
+
+    if (eventPages[url]) {
+      return {
+        getBody() {
+          return eventPages[url]
+        }
+      }
+    }
+
+    throw new Error(`Unexpected URL ${url}`)
+  })
+
+  const events = meetup.getNext({ meetupid: 'test-group' }, {})
+
+  assert.deepEqual(events, [{
+    title: 'Future Event',
+    date: new Date(futureDate).getTime(),
+    url: 'https://www.meetup.com/test-group/events/1/',
+    location: 'Online event'
+  }])
+  assert.equal(calls.length, 3)
+})
+
+test('Meetup getPrev returns an empty array', () => {
+  const meetup = loadMeetupWithMockedRequest(() => {
+    throw new Error('sync-request should not be called for getPrev')
+  })
+
+  assert.deepEqual(meetup.getPrev({ meetupid: 'test-group' }, {}), [])
+})

--- a/test/meetup.test.js
+++ b/test/meetup.test.js
@@ -91,6 +91,7 @@ test('Meetup getNext parses upcoming RSS events from JSON-LD pages', () => {
   const events = meetup.getNext({ meetupid: 'test-group' }, {})
 
   assert.deepEqual(events, [{
+    sourceId: 'test-group-1',
     title: 'Future Event',
     date: new Date(futureDate).getTime(),
     url: 'https://www.meetup.com/test-group/events/1/',

--- a/tests/meetup.e2e.test.js
+++ b/tests/meetup.e2e.test.js
@@ -1,0 +1,16 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const runMeetupE2E = process.env.ENABLE_E2E_MEETUP === '1' ? test : test.skip
+
+runMeetupE2E('Meetup E2E fetches one event from aindustriosa RSS', () => {
+  const meetup = require('../src/events/meetup.js')
+
+  const events = meetup.getNext({ meetupid: 'aindustriosa' }, {})
+
+  assert.equal(Array.isArray(events), true)
+  assert.equal(events.length, 1)
+  assert.equal(typeof events[0].title, 'string')
+  assert.equal(typeof events[0].url, 'string')
+  assert.equal(typeof events[0].date, 'number')
+})

--- a/tests/meetup.test.js
+++ b/tests/meetup.test.js
@@ -113,3 +113,49 @@ test('Meetup getPrev returns an empty array', () => {
 
   assert.deepEqual(meetup.getPrev({ meetupid: 'test-group' }, {}), [])
 })
+
+test('Meetup getNext falls back to parsing date ranges from description when JSON-LD date is missing', () => {
+  const now = Date.now()
+  const futureDate = new Date(now + 7 * 24 * 60 * 60 * 1000)
+  const month = futureDate.toLocaleString('en-US', { month: 'long', timeZone: 'UTC' })
+  const day = futureDate.getUTCDate()
+  const year = futureDate.getUTCFullYear()
+  const rssFeed = `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0">
+  <channel>
+    <item>
+      <title><![CDATA[Fallback Event]]></title>
+      <link>https://www.meetup.com/test-group/events/3/</link>
+      <description><![CDATA[📍 ONLINE<br />🗓 ${month} ${day}, ${year} | 18:00-20:30]]></description>
+    </item>
+  </channel>
+</rss>`
+
+  const meetup = loadMeetupWithMockedRequest((method, url) => {
+    if (url === 'https://www.meetup.com/test-group/events/rss/') {
+      return {
+        getBody() {
+          return rssFeed
+        },
+      }
+    }
+
+    if (url === 'https://www.meetup.com/test-group/events/3/') {
+      return {
+        getBody() {
+          return '<html><head></head><body>No event json-ld</body></html>'
+        },
+      }
+    }
+
+    throw new Error(`Unexpected URL ${url}`)
+  })
+
+  const events = meetup.getNext({ meetupid: 'test-group' }, {})
+
+  assert.equal(events.length, 1)
+  assert.equal(events[0].title, 'Fallback Event')
+  assert.equal(events[0].url, 'https://www.meetup.com/test-group/events/3/')
+  assert.equal(events[0].location, 'ONLINE')
+  assert.equal(typeof events[0].date, 'number')
+})

--- a/tests/meetup.test.js
+++ b/tests/meetup.test.js
@@ -45,25 +45,29 @@ test('Meetup getNext parses upcoming RSS events from JSON-LD pages', () => {
   </channel>
 </rss>`
   const eventPages = {
-    'https://www.meetup.com/test-group/events/1/': `<html><head><script type="application/ld+json">${JSON.stringify({
-      '@context': 'https://schema.org',
-      '@type': 'Event',
-      startDate: futureDate,
-      eventAttendanceMode: 'https://schema.org/OnlineEventAttendanceMode',
-      location: {
-        '@type': 'VirtualLocation',
-        url: 'https://www.meetup.com/test-group/events/1/'
-      }
-    })}</script></head></html>`,
-    'https://www.meetup.com/test-group/events/2/': `<html><head><script type="application/ld+json">${JSON.stringify({
-      '@context': 'https://schema.org',
-      '@type': 'Event',
-      startDate: pastDate,
-      location: {
-        '@type': 'Place',
-        name: 'Old venue'
-      }
-    })}</script></head></html>`
+    'https://www.meetup.com/test-group/events/1/': `<html><head><script type="application/ld+json" data-next-head="">${JSON.stringify(
+      {
+        '@context': 'https://schema.org',
+        '@type': 'Event',
+        startDate: futureDate,
+        eventAttendanceMode: 'https://schema.org/OnlineEventAttendanceMode',
+        location: {
+          '@type': 'VirtualLocation',
+          url: 'https://www.meetup.com/test-group/events/1/',
+        },
+      },
+    )}</script></head></html>`,
+    'https://www.meetup.com/test-group/events/2/': `<html><head><script type="application/ld+json" data-next-head="">${JSON.stringify(
+      {
+        '@context': 'https://schema.org',
+        '@type': 'Event',
+        startDate: pastDate,
+        location: {
+          '@type': 'Place',
+          name: 'Old venue',
+        },
+      },
+    )}</script></head></html>`,
   }
 
   const meetup = loadMeetupWithMockedRequest((method, url) => {
@@ -73,7 +77,7 @@ test('Meetup getNext parses upcoming RSS events from JSON-LD pages', () => {
       return {
         getBody() {
           return rssFeed
-        }
+        },
       }
     }
 
@@ -81,7 +85,7 @@ test('Meetup getNext parses upcoming RSS events from JSON-LD pages', () => {
       return {
         getBody() {
           return eventPages[url]
-        }
+        },
       }
     }
 
@@ -90,13 +94,15 @@ test('Meetup getNext parses upcoming RSS events from JSON-LD pages', () => {
 
   const events = meetup.getNext({ meetupid: 'test-group' }, {})
 
-  assert.deepEqual(events, [{
-    sourceId: 'test-group-1',
-    title: 'Future Event',
-    date: new Date(futureDate).getTime(),
-    url: 'https://www.meetup.com/test-group/events/1/',
-    location: 'Online event'
-  }])
+  assert.deepEqual(events, [
+    {
+      sourceId: 'test-group-1',
+      title: 'Future Event',
+      date: new Date(futureDate).getTime(),
+      url: 'https://www.meetup.com/test-group/events/1/',
+      location: 'Online event',
+    },
+  ])
   assert.equal(calls.length, 3)
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4,90 +4,61 @@
 
 "@types/concat-stream@^1.6.0":
   version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@types/concat-stream/-/concat-stream-1.6.0.tgz#394dbe0bb5fee46b38d896735e8b68ef2390d00d"
+  resolved "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz"
   dependencies:
     "@types/node" "*"
 
 "@types/form-data@0.0.33":
   version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-0.0.33.tgz#c9ac85b2a5fd18435b8c85d9ecb50e6d6c893ff8"
+  resolved "https://registry.npmjs.org/@types/form-data/-/form-data-0.0.33.tgz"
   dependencies:
     "@types/node" "*"
 
 "@types/node@*":
   version "13.9.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.3.tgz#6356df2647de9eac569f9a52eda3480fa9e70b4d"
+  resolved "https://registry.npmjs.org/@types/node/-/node-13.9.3.tgz"
 
 "@types/node@^10.0.3":
   version "10.17.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.17.tgz#7a183163a9e6ff720d86502db23ba4aade5999b8"
+  resolved "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz"
 
 "@types/node@^8.0.0":
   version "8.10.59"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.59.tgz#9e34261f30183f9777017a13d185dfac6b899e04"
+  resolved "https://registry.npmjs.org/@types/node/-/node-8.10.59.tgz"
 
 "@types/qs@^6.2.31":
   version "6.9.1"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.1.tgz#937fab3194766256ee09fcd40b781740758617e7"
-
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  dependencies:
-    event-target-shim "^5.0.0"
-
-agent-base@6:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.0.tgz#5d0101f19bbfaed39980b22ae866de153b93f09a"
-  dependencies:
-    debug "4"
-
-arrify@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
+  resolved "https://registry.npmjs.org/@types/qs/-/qs-6.9.1.tgz"
 
 asap@~2.0.6:
   version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  resolved "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
 
 asynckit@^0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-
-base64-js@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
-
-bignumber.js@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
-  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
-
-buffer-equal-constant-time@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
 
 buffer-from@^1.0.0:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  resolved "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz"
 
 caseless@^0.12.0, caseless@~0.12.0:
   version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+  resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
 
 colors@^1.3.3:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  resolved "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz"
 
 combined-stream@^1.0.6:
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
   dependencies:
     delayed-stream "~1.0.0"
 
 concat-stream@^1.6.0, concat-stream@^1.6.2:
   version "1.6.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  resolved "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz"
   dependencies:
     buffer-from "^1.0.0"
     inherits "^2.0.3"
@@ -96,126 +67,32 @@ concat-stream@^1.6.0, concat-stream@^1.6.2:
 
 core-util-is@~1.0.0:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-
-debug@4:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  dependencies:
-    ms "^2.1.1"
+  resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-
-ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
-  dependencies:
-    safe-buffer "^5.0.1"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
 
 entities@^2.0.3:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
+  resolved "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-
-extend@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
-
-fast-text-encoding@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.1.tgz#4a428566f74fc55ebdd447555b1eb4d9cf514455"
 
 form-data@^2.2.0:
   version "2.5.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
-gaxios@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/gaxios/-/gaxios-4.3.0.tgz#ad4814d89061f85b97ef52aed888c5dbec32f774"
-  integrity sha512-pHplNbslpwCLMyII/lHPWFQbJWOX0B3R1hwBEOvzYi1GmdKZruuEHK4N9V6f7tf1EaPYyF80mui1+344p6SmLg==
-  dependencies:
-    abort-controller "^3.0.0"
-    extend "^3.0.2"
-    https-proxy-agent "^5.0.0"
-    is-stream "^2.0.0"
-    node-fetch "^2.3.0"
-
-gcp-metadata@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/gcp-metadata/-/gcp-metadata-4.2.1.tgz#31849fbcf9025ef34c2297c32a89a1e7e9f2cd62"
-  integrity sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==
-  dependencies:
-    gaxios "^4.0.0"
-    json-bigint "^1.0.0"
-
 get-port@^3.1.0:
   version "3.2.0"
-  resolved "https://registry.yarnpkg.com/get-port/-/get-port-3.2.0.tgz#dd7ce7de187c06c8bf353796ac71e099f0980ebc"
-
-google-auth-library@^7.0.2:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-7.1.0.tgz#d83b6bed1d170e30649e15e9b5b17cb375e88919"
-  integrity sha512-X+gbkGjnLN3HUZP2W3KBREuA603BXd80ITvL0PeS0QpyDNYz/u0pIZ7aRuGnrSuUc0grk/qxEgtVTFt1ogbP+A==
-  dependencies:
-    arrify "^2.0.0"
-    base64-js "^1.3.0"
-    ecdsa-sig-formatter "^1.0.11"
-    fast-text-encoding "^1.0.0"
-    gaxios "^4.0.0"
-    gcp-metadata "^4.2.0"
-    gtoken "^5.0.4"
-    jws "^4.0.0"
-    lru-cache "^6.0.0"
-
-google-p12-pem@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-3.0.3.tgz#673ac3a75d3903a87f05878f3c75e06fc151669e"
-  integrity sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==
-  dependencies:
-    node-forge "^0.10.0"
-
-googleapis-common@^5.0.2:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/googleapis-common/-/googleapis-common-5.0.2.tgz#e2c4e777050b921e90657de1f2edec4e7c64a3e0"
-  integrity sha512-TL7qronKNZwE/XBvqshwzCPmZGq2gz/beXzANF7EVoO7FsQjOd7dk40DYrXkoCpvbnJHCQKWESq6NansiIPFqA==
-  dependencies:
-    extend "^3.0.2"
-    gaxios "^4.0.0"
-    google-auth-library "^7.0.2"
-    qs "^6.7.0"
-    url-template "^2.0.8"
-    uuid "^8.0.0"
-
-googleapis@^74.2.0:
-  version "74.2.0"
-  resolved "https://registry.yarnpkg.com/googleapis/-/googleapis-74.2.0.tgz#e3f44093594b56a13f6899e27fb842a7a6687a2a"
-  integrity sha512-AF8RwmTbz8GGIza9LViokOUAsrEkB6gKwvIGXbgWEWzZO1+DRsbKSstHotDgUA4zdXhVtGkOW7uqNs/wz4rYNA==
-  dependencies:
-    google-auth-library "^7.0.2"
-    googleapis-common "^5.0.2"
-
-gtoken@^5.0.4:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-5.2.1.tgz#4dae1fea17270f457954b4a45234bba5fc796d16"
-  integrity sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==
-  dependencies:
-    gaxios "^4.0.0"
-    google-p12-pem "^3.0.3"
-    jws "^4.0.0"
+  resolved "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz"
 
 http-basic@^8.1.1:
   version "8.1.3"
-  resolved "https://registry.yarnpkg.com/http-basic/-/http-basic-8.1.3.tgz#a7cabee7526869b9b710136970805b1004261bbf"
+  resolved "https://registry.npmjs.org/http-basic/-/http-basic-8.1.3.tgz"
   dependencies:
     caseless "^0.12.0"
     concat-stream "^1.6.2"
@@ -224,112 +101,59 @@ http-basic@^8.1.1:
 
 http-response-object@^3.0.1:
   version "3.0.2"
-  resolved "https://registry.yarnpkg.com/http-response-object/-/http-response-object-3.0.2.tgz#7f435bb210454e4360d074ef1f989d5ea8aa9810"
+  resolved "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz"
   dependencies:
     "@types/node" "^10.0.3"
 
-https-proxy-agent@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
-  dependencies:
-    agent-base "6"
-    debug "4"
-
 inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
-  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
-
-is-stream@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
 
 isarray@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-json-bigint@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/json-bigint/-/json-bigint-1.0.0.tgz#ae547823ac0cad8398667f8cd9ef4730f5b01ff1"
-  integrity sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==
-  dependencies:
-    bignumber.js "^9.0.0"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
 
 jsonschema@^1.4.0:
   version "1.4.0"
-  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.0.tgz#1afa34c4bc22190d8e42271ec17ac8b3404f87b2"
+  resolved "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz"
   integrity sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw==
-
-jwa@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/jwa/-/jwa-2.0.0.tgz#a7e9c3f29dae94027ebcaf49975c9345593410fc"
-  dependencies:
-    buffer-equal-constant-time "1.0.1"
-    ecdsa-sig-formatter "1.0.11"
-    safe-buffer "^5.0.1"
-
-jws@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/jws/-/jws-4.0.0.tgz#2d4e8cf6a318ffaa12615e9dec7e86e6c97310f4"
-  dependencies:
-    jwa "^2.0.0"
-    safe-buffer "^5.0.1"
-
-lru-cache@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
-  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
-  dependencies:
-    yallist "^4.0.0"
 
 mime-db@1.43.0:
   version "1.43.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz"
 
 mime-types@^2.1.12:
   version "2.1.26"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz"
   dependencies:
     mime-db "1.43.0"
 
 moment@^2.29.1:
   version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  resolved "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
-
-ms@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
-
-node-fetch@^2.3.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-
-node-forge@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
-  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 parse-cache-control@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/parse-cache-control/-/parse-cache-control-1.0.1.tgz#8eeab3e54fa56920fe16ba38f77fa21aacc2d74e"
+  resolved "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
-  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"
 
 promise@^8.0.0:
   version "8.1.0"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
+  resolved "https://registry.npmjs.org/promise/-/promise-8.1.0.tgz"
   dependencies:
     asap "~2.0.6"
 
-qs@^6.4.0, qs@^6.7.0:
+qs@^6.4.0:
   version "6.9.2"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.2.tgz#a27b695006544a04bf0e6c6a7e8120778926d5bd"
+  resolved "https://registry.npmjs.org/qs/-/qs-6.9.2.tgz"
 
 readable-stream@^2.2.2:
   version "2.3.7"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
@@ -341,33 +165,33 @@ readable-stream@^2.2.2:
 
 rss-parser@^3.12.0:
   version "3.12.0"
-  resolved "https://registry.yarnpkg.com/rss-parser/-/rss-parser-3.12.0.tgz#b8888699ea46304a74363fbd8144671b2997984c"
+  resolved "https://registry.npmjs.org/rss-parser/-/rss-parser-3.12.0.tgz"
   integrity sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==
   dependencies:
     entities "^2.0.3"
     xml2js "^0.4.19"
 
-safe-buffer@^5.0.1:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@~5.1.0:
   version "5.1.2"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
+
+safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
 
 sax@>=0.6.0:
   version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  resolved "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
 
 string_decoder@~1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
   dependencies:
     safe-buffer "~5.1.0"
 
 sync-request@^6.1.0:
   version "6.1.0"
-  resolved "https://registry.yarnpkg.com/sync-request/-/sync-request-6.1.0.tgz#e96217565b5e50bbffe179868ba75532fb597e68"
+  resolved "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz"
   dependencies:
     http-response-object "^3.0.1"
     sync-rpc "^1.2.1"
@@ -375,13 +199,13 @@ sync-request@^6.1.0:
 
 sync-rpc@^1.2.1:
   version "1.3.6"
-  resolved "https://registry.yarnpkg.com/sync-rpc/-/sync-rpc-1.3.6.tgz#b2e8b2550a12ccbc71df8644810529deb68665a7"
+  resolved "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz"
   dependencies:
     get-port "^3.1.0"
 
 then-request@^6.0.0:
   version "6.0.2"
-  resolved "https://registry.yarnpkg.com/then-request/-/then-request-6.0.2.tgz#ec18dd8b5ca43aaee5cb92f7e4c1630e950d4f0c"
+  resolved "https://registry.npmjs.org/then-request/-/then-request-6.0.2.tgz"
   dependencies:
     "@types/concat-stream" "^1.6.0"
     "@types/form-data" "0.0.33"
@@ -397,33 +221,19 @@ then-request@^6.0.0:
 
 typedarray@^0.0.6:
   version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-
-url-template@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
+  resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
-
-uuid@^8.0.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
 
 xml2js@^0.4.19:
   version "0.4.23"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  resolved "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz"
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"
 
 xmlbuilder@~11.0.0:
   version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-
-yallist@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
-  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+  resolved "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz"


### PR DESCRIPTION
## Summary
- fix Meetup JSON-LD extraction to support script tags with additional attributes (for example data-next-head)
- support Event discovery across direct JSON-LD objects, arrays, and @graph payloads
- move Meetup unit test to tests/meetup.test.js and add coverage for attributed JSON-LD script tags
- add a live network E2E test at tests/meetup.e2e.test.js, gated behind ENABLE_E2E_MEETUP=1 so it is skipped by default

## Validation
- node --test tests/meetup.test.js tests/meetup.e2e.test.js (E2E skipped by default)
- ENABLE_E2E_MEETUP=1 node --test tests/meetup.e2e.test.js (passes live against aindustriosa RSS)
