### PR TITLE
fix: add release-please-config.json to properly wire manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ typings/
 
 # Serverless directories
 .serverless
+
+# Build output
+dist/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metagroup-schema-tools",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "description": "Metagroup (like vigotech.org) schema tools",
   "main": "src/index.js",
   "scripts": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,7 @@
+{
+  "packages": {
+    ".": {
+      "release-type": "node"
+    }
+  }
+}


### PR DESCRIPTION
Adds `release-please-config.json` so Release Please reads version from `release-please-manifest.json` instead of auto-configuring from `package.json`.

Also resets `package.json` version to `1.1.2` (matching manifest) and adds `dist/` to `.gitignore`.

**After merging:** Release Please will detect the manifest version (1.1.2) and conventional commits, then create a release PR bumping to the correct next version.